### PR TITLE
Minor fixups

### DIFF
--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -279,13 +279,13 @@ def command_line_parser():
     parser = argparse.ArgumentParser(
         prog="dmtest", description="run device-mapper tests"
     )
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(title="command arguments", help="'{cmd} -h' for command specific options", metavar="command")
 
     result_sets_p = subparsers.add_parser("result-sets", help="list result sets")
     result_sets_p.set_defaults(func=cmd_result_sets)
 
     result_set_delete_p = subparsers.add_parser(
-        "result-set-delete", help="list result sets"
+        "result-set-delete", help="delete result set"
     )
     result_set_delete_p.set_defaults(func=cmd_result_set_delete)
     result_set_delete_p.add_argument("result_set", help="The result set to delete")
@@ -295,7 +295,7 @@ def command_line_parser():
     arg_filter(list_p)
     arg_result_set(list_p)
 
-    log_p = subparsers.add_parser("log", help="list tests")
+    log_p = subparsers.add_parser("log", help="list test logs")
     log_p.set_defaults(func=cmd_log)
     arg_filter(log_p)
     arg_result_set(log_p)

--- a/src/dmtest/blktrace.py
+++ b/src/dmtest/blktrace.py
@@ -2,6 +2,7 @@ import logging as log
 import re
 import subprocess
 import time
+import dmtest.dependency_tracker as dep
 
 from typing import List, NamedTuple
 
@@ -46,6 +47,8 @@ class BlkTrace:
         else:
             blktrace_cmd.extend(["-a", "queue"])
 
+        dep.add_exe("blktrace")
+        dep.add_exe("blkparse")
         log.info(f"starting blktrace: {blktrace_cmd}")
         self._blktrace = subprocess.Popen(
             blktrace_cmd,

--- a/test_dependencies.toml
+++ b/test_dependencies.toml
@@ -7,7 +7,7 @@ executables = [ "blockdev", "dd", "dmsetup", "echo", "mkfs.xfs", "mount", "umoun
 targets = [ "thin", "thin-pool",]
 
 ["/bufio/create"]
-executables = [ "blockdev", "dmsetup",]
+executables = [ "blockdev", "dmsetup", "modprobe",]
 targets = [ "bufio_test",]
 
 ["/bufio/empty-program"]
@@ -135,11 +135,11 @@ executables = [ "blockdev", "dd", "dmsetup",]
 targets = [ "thin-pool",]
 
 ["/thin/discard/blktrace"]
-executables = [ "blockdev", "dd", "dmsetup", "thin_dump",]
+executables = [ "blkparse", "blktrace", "blockdev", "dd", "dmsetup", "thin_dump",]
 targets = [ "thin", "thin-pool",]
 
 ["/thin/discard/unmaps-passdown-discardable"]
-executables = [ "blockdev", "dd", "dmsetup",]
+executables = [ "blkparse", "blktrace", "blockdev", "dd", "dmsetup",]
 targets = [ "thin", "thin-pool",]
 
 ["/thin/discard/xml-tests"]


### PR DESCRIPTION
Fix some minor issues I noticed while using dmtest. The usage could be more helpful and the the health command didn't check for blktrace, even though tests require it.