### PR TITLE
Add --state option and compare command

### DIFF
--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -206,6 +206,9 @@ def cmd_run(tests, args, results: db.TestResults):
 # 'health' command
 
 
+def is_repo(path):
+    return os.path.isdir(os.path.join(path, ".git"))
+
 def which(executable):
     (return_code, stdout, stderr) = process.run(f"which {executable}", raise_on_fail=False)
     if return_code == 0:
@@ -238,6 +241,11 @@ def has_target(target):
 
 def cmd_health(tests, args, results):
     test_deps = dep.read_test_deps(test_dep_path)
+
+    print("Kernel Repo:\n")
+    repo = "linux"
+    found = "present" if os.path.isdir(os.path.join(repo, ".git")) else "missing"
+    print(f"{repo.ljust(40,'.')} {found}\n\n")
 
     print("Executables:\n")
     tools = test_deps.get_all_executables()

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -83,7 +83,7 @@ def cmd_result_sets(tests, args, results: db.TestResults):
 # 'result-set-delete' command
 
 
-def cmd_result_set_delete(tests, args, results: db.TestResult):
+def cmd_result_set_delete(tests, args, results: db.TestResults):
     try:
         results.delete_result_set(args.result_set)
     except db.NoSuchResultSet:

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -207,7 +207,7 @@ def cmd_run(tests, args, results: db.TestResults):
 
 
 def which(executable):
-    (return_code, stdout, stderr) = process.run(f"which {executable}")
+    (return_code, stdout, stderr) = process.run(f"which {executable}", raise_on_fail=False)
     if return_code == 0:
         return stdout
     else:


### PR DESCRIPTION
For the state option, I used "^" to invert the match, since "!" and "~" already have special meanings in bash, wherever they appear in a command. Also I added a check for the kernel repo to the health command, on the grounds that IMHO if the health command doesn't flag anything as missing, dmtest shouldn't fail tests due a missing prerequisite.