### PR TITLE
Dependency fixes and cleanups

### DIFF
--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -174,23 +174,26 @@ def cmd_log(tests: test_register.TestRegister, args, results: db.TestResults):
     filter = build_filter(args)
     paths = sorted(tests.paths(results, result_set, filter))
 
-    if args.run_nr is None:
-        args.run_nr = 0
-
     if len(paths) == 0:
         print("No matching tests found.")
 
     for p in paths:
         res_list = results.get_test_results(p, result_set, args.run_nr)
-        if len(res_list):
-            if len(paths) > 1:
-                print(f"*** LOG FOR {p}, {len(res_list[0].log)} ***")
-            print(res_list[0].log)
+        if len(res_list) == 0:
+            print(f"*** NO LOG FOR {p}")
+            continue
+        for result in res_list:
+            if len(paths) > 1 or len(res_list) > 1:
+                msg = ""
+                if len(paths) > 1:
+                    msg += f" {p}"
+                if len(res_list) > 1:
+                    msg += f" RUN {result.run_nr}"
+                print(f"*** LOG FOR{msg}, {len(result.log)} ***")
+            print(result.log)
             if args.with_dmesg:
                 print("*** KERNEL LOG ***")
-                print(res_list[0].dmesg)
-        else:
-            print(f"*** NO LOG FOR {p}")
+                print(result.dmesg)
 
 
 # -----------------------------------------

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -393,10 +393,6 @@ def cmd_run(tests: test_register.TestRegister, args, results: db.TestResults):
 # 'health' command
 
 
-def is_repo(path):
-    return os.path.isdir(os.path.join(path, ".git"))
-
-
 def which(executable):
     exe_path = shutil.which(executable)
     return exe_path if exe_path else "-"
@@ -407,7 +403,7 @@ def cmd_health(tests: test_register.TestRegister, args, results):
 
     print("Kernel Repo:\n")
     repo = os.getenv("DMTEST_KERNEL_SOURCE", "linux")
-    found = "present" if is_repo(repo) else "missing"
+    found = "present" if test_register.has_repo(repo) else "missing"
     print(f"{repo.ljust(40,'.')} {found}\n\n")
 
     print("Executables:\n")

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -538,7 +538,7 @@ def command_line_parser():
     result_set_delete_p.set_defaults(func=cmd_result_set_delete)
     result_set_delete_p.add_argument("result_set", help="The result set to delete")
 
-    list_p = subparsers.add_parser("list", help="list tests")
+    list_p = subparsers.add_parser("list", help="list test results")
     list_p.set_defaults(func=cmd_list)
     arg_filter(list_p)
     arg_result_set(list_p)
@@ -583,7 +583,7 @@ def command_line_parser():
     )
     arg_result_set(compare_p)
 
-    list_runs_p = subparsers.add_parser("list-runs", help="list all runs in a result set")
+    list_runs_p = subparsers.add_parser("list-runs", help="list each test run individually")
     list_runs_p.set_defaults(func=cmd_list_runs)
     arg_filter(list_runs_p)
     arg_result_set(list_runs_p)

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -383,6 +383,7 @@ def cmd_run(tests: test_register.TestRegister, args, results: db.TestResults):
 
             pass_str = None
             if missing_dep:
+                log.info(f"Missing dependency: {missing_dep}")
                 print(f"MISSING_DEP [{missing_dep}]")
                 pass_str = "MISSING_DEP"
             elif passed:

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -333,6 +333,8 @@ def cmd_run(tests: test_register.TestRegister, args, results: db.TestResults):
             start = time.time()
             try:
                 with dep.dep_tracker() as tracker:
+                    old_deps = test_deps.get_deps(p)
+                    tests.check_deps(old_deps)
                     tests.run(p, fix)
                     exes = tracker.executables
                     targets = tracker.targets

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -364,7 +364,7 @@ def cmd_run(tests: test_register.TestRegister, args, results: db.TestResults):
                 pass_str = "FAIL"
 
             start_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(start))
-            start_str += str(start % 1)[1:]
+            start_str += f"{start % 1:f}"[1:]
             dmesg_cmd = ["journalctl", "--dmesg", "--since", start_str]
             try:
                 dmesg_log = subprocess.run(

--- a/src/dmtest/blk_archive/rolling_snaps.py
+++ b/src/dmtest/blk_archive/rolling_snaps.py
@@ -11,6 +11,7 @@ import dmtest.tvm as tvm
 import dmtest.units as units
 import dmtest.utils as utils
 import dmtest.pattern_stomper as stomper
+import dmtest.test_register as reg
 
 import os
 import threading
@@ -76,6 +77,6 @@ def register(tests):
     tests.register_batch(
         "/blk-archive/",
         [
-            ("rolling-snaps", t_rolling_snaps),
+            ("rolling-snaps", t_rolling_snaps, reg.check_linux_repo),
         ],
     )

--- a/src/dmtest/bufio/bufio_tests.py
+++ b/src/dmtest/bufio/bufio_tests.py
@@ -674,5 +674,4 @@ def register(tests):
             ("many-caches", t_multiple_caches),
             ("evict-old", t_evict_old),
         ],
-        dep_fn=reg.check_target("bufio_test"),
     )

--- a/src/dmtest/bufio/bufio_tests.py
+++ b/src/dmtest/bufio/bufio_tests.py
@@ -674,5 +674,5 @@ def register(tests):
             ("many-caches", t_multiple_caches),
             ("evict-old", t_evict_old),
         ],
-        dep_fn=reg.has_target("bufio_test"),
+        dep_fn=reg.check_target("bufio_test"),
     )

--- a/src/dmtest/dependency_tracker.py
+++ b/src/dmtest/dependency_tracker.py
@@ -7,9 +7,9 @@ from contextlib import contextmanager
 
 
 class DepTracker:
-    def __init__(self):
-        self._executables = set()
-        self._targets = set()
+    def __init__(self, executables=(), targets=()):
+        self._executables = set(executables)
+        self._targets = set(targets)
 
     def add_executable(self, exe):
         self._executables.add(exe)
@@ -30,6 +30,13 @@ class TestDeps:
     def __init__(self):
         self._deps = {}
         self._updated = False
+
+    def get_deps(self, test_name: str) -> DepTracker:
+        try:
+            dep = self._deps[test_name]
+            return DepTracker(dep["executables"], dep["targets"])
+        except KeyError:
+            return DepTracker()
 
     def set_deps(self, test_name, exes, targets):
         new_dep = {"executables": exes, "targets": targets}

--- a/src/dmtest/test_register.py
+++ b/src/dmtest/test_register.py
@@ -2,6 +2,7 @@ import re
 import shutil
 import dmtest.fixture as fixture
 import dmtest.process as process
+import dmtest.dependency_tracker as dep
 
 from typing import NamedTuple, Callable
 
@@ -58,6 +59,14 @@ class TestRegister:
 
         return selected
 
+    def check_deps(self, deps: dep.DepTracker):
+        for target in deps.targets:
+            if not has_target(target):
+                raise MissingTestDep(f"{target} target")
+        for exe in deps.executables:
+            if shutil.which(exe) is None:
+                raise MissingTestDep(f"{exe} executable")
+
     def run(self, path, fix):
         t = self._tests[path]
         if t:
@@ -89,19 +98,3 @@ def has_target(target: str) -> bool:
 
     (code, stdout, stderr) = process.run(f"modprobe {kmod}", raise_on_fail=False)
     return code == 0
-
-
-def check_target(name: str):
-    def check():
-        if not has_target(name):
-            raise MissingTestDep(f"{name} target")
-
-    return check
-
-
-def check_exe(name: str):
-    def check():
-        if shutil.which(name) is None:
-            raise MissingTestDep(f"{name} executable")
-
-    return check

--- a/src/dmtest/test_register.py
+++ b/src/dmtest/test_register.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import subprocess
 import dmtest.fixture as fixture
 import dmtest.process as process
 import dmtest.dependency_tracker as dep
@@ -93,7 +94,12 @@ targets_to_kmodules = {
 
 def has_target(target: str) -> bool:
     # It may already be loaded or compiled in
-    (_, stdout, stderr) = process.run("dmsetup targets")
+    stdout = subprocess.run(
+        ["dmsetup", "targets"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True
+    ).stdout
     if target in stdout:
         return True
 
@@ -102,8 +108,11 @@ def has_target(target: str) -> bool:
     except KeyError:
         kmod = f"dm_{target}"
 
-    (code, stdout, stderr) = process.run(f"modprobe {kmod}", raise_on_fail=False)
-    return code == 0
+    return subprocess.run(
+        ["modprobe", kmod],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ).returncode == 0
 
 
 def has_repo(path: str) -> bool:

--- a/src/dmtest/thin/snapshot_tests.py
+++ b/src/dmtest/thin/snapshot_tests.py
@@ -11,6 +11,7 @@ import dmtest.tvm as tvm
 import dmtest.units as units
 import dmtest.utils as utils
 import dmtest.pattern_stomper as stomper
+import dmtest.test_register as reg
 
 import os
 import threading
@@ -298,8 +299,8 @@ def register(tests):
             ("many-snapshots-of-same-volume", t_many_snapshots_of_same_volume),
             ("parallel-io-to-shared-thins", t_parallel_io_to_shared_thins),
             ("ref-count-tree", t_ref_count_tree),
-            ("many-snaps-with-changes", t_many_snaps_with_changes),
-            ("try-and-create-duplicates", t_try_and_create_duplicates),
+            ("many-snaps-with-changes", t_many_snaps_with_changes, reg.check_linux_repo),
+            ("try-and-create-duplicates", t_try_and_create_duplicates, reg.check_linux_repo),
         ],
     )
     tests.register_batch(


### PR DESCRIPTION
Make sure all tests check their dependencies. If they're missing, skip the test instead of failing. Also a few miscellaneous cleanups.