### PR TITLE
Minor features and fix

### DIFF
--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -504,7 +504,8 @@ def arg_run_nr(p):
 
 def command_line_parser():
     parser = argparse.ArgumentParser(
-        prog="dmtest", description="run device-mapper tests"
+        prog="dmtest", description="run device-mapper tests",
+        fromfile_prefix_chars="@", epilog="Arguments starting with @ will be treaded as files containing one argument per line, and will be replaced with the arguments they contain.",
     )
     subparsers = parser.add_subparsers(
         title="command arguments",

--- a/src/dmtest/__main__.py
+++ b/src/dmtest/__main__.py
@@ -100,6 +100,20 @@ def cmd_result_set_delete(
 
 
 # -----------------------------------------
+# -----------------------------------------
+# 'result-set-rename' command
+
+
+def cmd_result_set_rename(
+    tests: test_register.TestRegister, args, results: db.TestResults
+):
+    try:
+        results.rename_result_set(args.old_result_set, args.new_result_set)
+    except (db.NoSuchResultSet, db.ResultSetInUse) as e:
+        print(str(e), file=sys.stderr)
+
+
+# -----------------------------------------
 # 'list' command
 
 class AvgResult(NamedTuple):
@@ -521,6 +535,17 @@ def command_line_parser():
     )
     result_set_delete_p.set_defaults(func=cmd_result_set_delete)
     result_set_delete_p.add_argument("result_set", help="The result set to delete")
+
+    result_set_rename_p = subparsers.add_parser(
+        "result-set-rename", help="rename result set"
+    )
+    result_set_rename_p.set_defaults(func=cmd_result_set_rename)
+    result_set_rename_p.add_argument(
+        "old_result_set", help="The old result set name"
+    )
+    result_set_rename_p.add_argument(
+        "new_result_set", help="The new result set name"
+    )
 
     list_p = subparsers.add_parser("list", help="list test results")
     list_p.set_defaults(func=cmd_list)

--- a/src/dmtest/db.py
+++ b/src/dmtest/db.py
@@ -17,6 +17,10 @@ class NoSuchResultSet(Exception):
     pass
 
 
+class ResultSetInUse(Exception):
+    pass
+
+
 class TestResults:
     def __init__(self, path):
         # Connect to the SQLite database (create the file if it doesn't exist)
@@ -212,5 +216,21 @@ class TestResults:
         # Remove the result set
         cursor.execute(
             "DELETE FROM result_sets WHERE result_set_id = ?", (result_set_id,)
+        )
+        self._conn.commit()
+
+    def rename_result_set(self, old_result_set, new_result_set):
+        cursor = self._conn.cursor()
+        result_set_id = self.get_result_set_id(old_result_set)
+
+        if result_set_id is None:
+            raise NoSuchResultSet(f"Result set '{old_result_set}' not found")
+
+        if self.get_result_set_id(new_result_set) is not None:
+            raise ResultSetInUse(f"Result set '{new_result_set}' already exists")
+
+        cursor.execute(
+            "UPDATE result_sets SET result_set = ? WHERE result_set_id = ?",
+            (new_result_set, result_set_id)
         )
         self._conn.commit()


### PR DESCRIPTION
Tests were failing in the CKI when they were run on top of partitions instead of full devices, due to the lack of syncing when wiping the metadata device.  Fix that, and add the ability to specify arguments in a file, and rename results sets.