### PR TITLE
Add numpy to the requirements because gendatablock.py depends on it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 toml==0.10.2
 pudb
+numpy


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/dmtest-python/src/dmtest/__main__.py", line 9, in <module>
    import dmtest.vdo.register as vdo_register
  File "/opt/dmtest-python/src/dmtest/vdo/register.py", line 3, in <module>
    import dmtest.vdo.dedupe_tests as vdo_dedupe
  File "/opt/dmtest-python/src/dmtest/vdo/dedupe_tests.py", line 4, in <module>
    import dmtest.gendatablocks as generator
  File "/opt/dmtest-python/src/dmtest/gendatablocks.py", line 9, in <module>
    import numpy
ModuleNotFoundError: No module named 'numpy'