### PR TITLE
Fix compatibility with Python < 3.11 by specifying byteorder in int conversion

### DIFF
--- a/src/dmtest/gendatablocks.py
+++ b/src/dmtest/gendatablocks.py
@@ -93,7 +93,7 @@ class Header:
             the seed calculated from the Header
 
         """
-        return int.from_bytes(self.to_bytes())
+        return int.from_bytes(self.to_bytes(), byteorder='big')
 
     def to_bytes(self) -> bytes:
         """get a bytes array representation of the Header


### PR DESCRIPTION
Running vdo dedupe tests with Python 3.9 threw an exception: "ERROR Exception caught: from_bytes() missing required argument 'byteorder' (pos 2)". Default argument value for byteorder was added in 3.11 https://docs.python.org/3.11/library/stdtypes.html#int.from_bytes. 