### PR TITLE
Add pyyaml to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 toml==0.10.2
 pudb
 numpy
+pyyaml


### PR DESCRIPTION
./dmtest health
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/dmtest-python/src/dmtest/__main__.py", line 10, in <module>
    import dmtest.vdo.register as vdo_register
  File "/opt/dmtest-python/src/dmtest/vdo/register.py", line 1, in <module>
    import dmtest.vdo.compress_tests as vdo_compress
  File "/opt/dmtest-python/src/dmtest/vdo/compress_tests.py", line 5, in <module>
    from dmtest.vdo.stats import vdo_stats
  File "/opt/dmtest-python/src/dmtest/vdo/stats.py", line 5, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'